### PR TITLE
Fix job artifact URL rewriting

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -352,6 +352,9 @@ static void downloadAsset(const Asset& a, const std::string& token) {
         size_t art = url.find("/artifacts/", id_end);
         if (art != std::string::npos) {
           std::string rest = url.substr(art + strlen("/artifacts/"));
+          const std::string rawPrefix = "raw/";
+          if (rest.rfind(rawPrefix, 0) == 0)
+            rest = rest.substr(rawPrefix.size());
           url = domain + "/api/v4/projects/" + urlEncodeProject(project) + "/jobs/" + jobId + "/artifacts/" + rest;
         }
       }


### PR DESCRIPTION
## Summary
- ensure the converted API URL drops leading `raw/` when fetching job artifact assets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68890a8db5dc8320a8a92a89a9f05f38